### PR TITLE
Force sign out when an authorized request fails with denied access

### DIFF
--- a/Example/Tests/SENAPIClientSpec.m
+++ b/Example/Tests/SENAPIClientSpec.m
@@ -7,7 +7,7 @@
 @interface SENAPIClient (Private)
 
 + (NSString*)urlEncode:(NSString*)URLString;
-
++ (AFHTTPSessionManager*)HTTPSessionManager;
 @end
 
 SPEC_BEGIN(SENAPIClientSpec)
@@ -40,7 +40,7 @@ describe(@"SENAPIClient", ^{
     });
 
     beforeEach(^{
-        sessionManager = [[SENAPIClient class] performSelector:@selector(HTTPSessionManager)];
+        sessionManager = [SENAPIClient HTTPSessionManager];
     });
 
     afterEach(^{

--- a/Pod/Classes/API/SENAPIClient.m
+++ b/Pod/Classes/API/SENAPIClient.m
@@ -3,10 +3,9 @@
 #import <NSJSONSerialization-NSNullRemoval/NSJSONSerialization+RemovingNulls.h>
 
 #import "SENAPIClient.h"
+#import "SENAuthorizationService.h"
 
 static NSString* const SENDefaultBaseURLPath = @"https://dev-api.hello.is/v1";
-//static NSString* const SENDefaultBaseURLPath = @"http://192.168.128.88:9999";
-// static NSString* const SENDefaultBaseURLPath = @"http://192.168.128.151:9999/v1";
 static NSString* const SENAPIClientBaseURLPathKey = @"SENAPIClientBaseURLPathKey";
 static AFHTTPSessionManager* sessionManager = nil;
 
@@ -16,6 +15,10 @@ typedef void (^SENAFFailureBlock)(NSURLSessionDataTask *, NSError *);
 typedef void (^SENAFSuccessBlock)(NSURLSessionDataTask *, id responseObject);
 SENAFFailureBlock (^SENAPIClientRequestFailureBlock)(SENAPIDataBlock) = ^SENAFFailureBlock(SENAPIDataBlock completion) {
     return ^(NSURLSessionDataTask *task, NSError *error) {
+        if ([SENAuthorizationService isAuthorizationError:error]
+            && [SENAuthorizationService isAuthorizedRequest:task.originalRequest]) {
+            [SENAuthorizationService deauthorize];
+        }
         if (completion)
             completion(nil, error);
     };

--- a/Pod/Classes/API/SENAuthorizationService.h
+++ b/Pod/Classes/API/SENAuthorizationService.h
@@ -39,6 +39,24 @@ extern NSString* const SENAuthorizationServiceDidDeauthorizeNotification;
 + (BOOL)isAuthorized;
 
 /**
+ *  Checks whether an error indicates an invalid API access token
+ *
+ *  @param error error to check
+ *
+ *  @return YES if the error indicates the token is deauthorized
+ */
++ (BOOL)isAuthorizationError:(NSError*)error;
+
+/**
+ *  Checks whether a request has an authorization
+ *
+ *  @param request request to check
+ *
+ *  @return YES if the request has an authorization header set
+ */
++ (BOOL)isAuthorizedRequest:(NSURLRequest*)request;
+
+/**
  *  Authenticated email address or nil
  */
 + (NSString*)emailAddressOfAuthorizedUser;

--- a/Pod/Classes/API/SENAuthorizationService.m
+++ b/Pod/Classes/API/SENAuthorizationService.m
@@ -5,6 +5,7 @@
 #import <FXKeychain/FXKeychain.h>
 
 #import "SENAuthorizationService.h"
+#import "SENAPIAccount.h"
 #import "SENAPIClient.h"
 
 NSString* const SENAuthorizationServiceKeychainService = @"is.hello.Sense";
@@ -20,6 +21,7 @@ static NSString* const SENAuthorizationServiceCredentialsKey = @"credentials";
 static NSString* const SENAuthorizationServiceCredentialsEmailKey = @"email";
 static NSString* const SENAuthorizationServiceAccountIdKey = @"account_id";
 static NSString* const SENAuthorizationServiceAccessTokenKey = @"access_token";
+static NSInteger const SENAuthorizationServiceDeauthorizationCode = 401;
 static NSString* const SENAuthorizationServiceAuthorizationHeaderKey = @"Authorization";
 
 + (FXKeychain*)keychain {
@@ -86,6 +88,17 @@ static NSString* const SENAuthorizationServiceAuthorizationHeaderKey = @"Authori
     }
 
     return token != nil;
+}
+
++ (BOOL)isAuthorizedRequest:(NSURLRequest*)request
+{
+    return request.allHTTPHeaderFields[SENAuthorizationServiceAuthorizationHeaderKey] != nil;
+}
+
++ (BOOL)isAuthorizationError:(NSError*)error
+{
+    NSHTTPURLResponse* response = error.userInfo[AFNetworkingOperationFailingURLResponseErrorKey];
+    return response.statusCode == SENAuthorizationServiceDeauthorizationCode;
 }
 
 + (NSString*)emailAddressOfAuthorizedUser


### PR DESCRIPTION
## Changes
- Adds a check to all failing requests for an access token and whether the request failed with an "unauthorized" status code
## Notes
- It is possible that a request could be sent before authorization occurs in the app, like when a view is loaded from a storyboard during initialization. This case should be handled because requests without tokens do not force sign out.
- It is possible that a user has a valid token, but that token is invalid for additional permissions which were added to the OAuth app after the user was signed in, failing a request. This case should be handled because that user needs to sign out and in again to gain the additional features.
- It is possible that a request fails for totally unrelated reasons to authorization, and this should not force sign out.
