### PR TITLE
Questions - Remove observers, let UI handle refresh

### DIFF
--- a/Example/Tests/SENServiceQuestionsSpec.m
+++ b/Example/Tests/SENServiceQuestionsSpec.m
@@ -37,27 +37,11 @@ describe(@"SENServiceQuestionsSpec", ^{
         
     });
     
-    describe(@"-setQuestionsAskedToday", ^{
-        
-        it(@"should set key in NSUserDefaults to", ^{
-            
-            SENServiceQuestions* service = [SENServiceQuestions sharedService];
-            [service setQuestionsAskedToday];
-            
-            NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-            id object = [defaults objectForKey:@"kSENServiceQuestionsKeyDate"];
-            [[object should] beNonNil];
-            
-        });
-        
-    });
-    
     describe(@"-updateQuestions:", ^{
         
-        it(@"should return nil for questions if already asked", ^{
+        it(@"should return nil for questions if not authorized", ^{
             
             SENServiceQuestions* service = [SENServiceQuestions sharedService];
-            [service setQuestionsAskedToday];
             
             __block NSArray* fakeQuestions = nil;
             __block NSError* noError = nil;

--- a/Pod/Classes/API/SENAPIAccount.h
+++ b/Pod/Classes/API/SENAPIAccount.h
@@ -58,4 +58,13 @@ extern NSString* const kSENAccountNotificationAccountCreated;
          toNewPassword:(NSString*)password
        completionBlock:(SENAPIDataBlock)completion;
 
+/**
+ * Change the email for the specified account.  The email in the account object
+ * is a
+ * 
+ * @param email: the new email to be used instead, which will still undergo
+ *               various validation.
+ */
++ (void)changeEmailInAccount:(SENAccount*)account completionBlock:(SENAPIDataBlock)completion;
+
 @end

--- a/Pod/Classes/API/SENAPIAccount.m
+++ b/Pod/Classes/API/SENAPIAccount.m
@@ -99,6 +99,21 @@ NSString* const SENAPIAccountErrorDomain = @"is.hello.account";
     [SENAPIClient POST:path parameters:body completion:completion];
 }
 
++ (void)changeEmailInAccount:(SENAccount*)account completionBlock:(SENAPIDataBlock)completion {
+    if (account == nil || [[account email] length] == 0) {
+        if (completion) {
+            completion (nil, [NSError errorWithDomain:SENAPIAccountErrorDomain
+                                                 code:SENAPIAccountErrorInvalidArgument
+                                             userInfo:nil]);
+        }
+        return;
+    }
+    
+    NSDictionary* body = [self dictionaryValue:account];
+    NSString* path = [SENAPIAccountEndpoint stringByAppendingPathComponent:@"email"];
+    [SENAPIClient POST:path parameters:body completion:completion];
+}
+
 #pragma mark - Helpers
 
 + (NSString*)stringValueOfGender:(SENAccountGender)gender {

--- a/Pod/Classes/Model/SENQuestion.m
+++ b/Pod/Classes/Model/SENQuestion.m
@@ -37,4 +37,16 @@
     return self;
 }
 
+- (BOOL)isEqual:(id)object {
+    if (object == nil) return NO;
+    if (![object isKindOfClass:[self class]]) return NO;
+    
+    SENQuestion* otherQuestion = (SENQuestion*)object;
+    return [[otherQuestion questionId] isEqualToNumber:[self questionId]];
+}
+
+- (NSUInteger)hash {
+    return [[self questionId] hash];
+}
+
 @end

--- a/Pod/Classes/Service/SENServiceQuestions.h
+++ b/Pod/Classes/Service/SENServiceQuestions.h
@@ -34,13 +34,6 @@ typedef NS_ENUM(NSUInteger, SENServiceQuestionsErrorCode) {
 - (BOOL)isUpdating;
 
 /**
- * Inform the service that the questions have been presented
- * to the user, which will stop any further actions until the
- * next cycle
- */
-- (void)setQuestionsAskedToday;
-
-/**
  * Update questions, if any.
  *
  * @param completion: called upon completion of updating questions.


### PR DESCRIPTION
Let the UI call refresh / update of questions.  If we let the service update, it's difficult to sync up with the new design of the questions UI
