### PR TITLE
Re-authorization

### DIFF
--- a/Example/Tests/SENServiceAccountSpec.m
+++ b/Example/Tests/SENServiceAccountSpec.m
@@ -44,14 +44,6 @@ describe(@"SENServiceAccountSpec", ^{
             [[expectFutureValue(@([invalidError code])) should] equal:@(SENServiceAccountErrorInvalidArg)];
         });
         
-        it(@"should call refreshAccount:", ^{
-            
-            SENServiceAccount* service = [SENServiceAccount sharedService];
-            [[service should] receive:@selector(refreshAccount:)];
-            [service changePassword:@"test" toNewPassword:@"test123" completion:nil];
-            
-        });
-        
     });
     
     describe(@"-changeEmail:completion", ^{

--- a/Pod/Classes/API/SENAuthorizationService.h
+++ b/Pod/Classes/API/SENAuthorizationService.h
@@ -11,6 +11,11 @@ extern NSString* const SENAuthorizationServiceDidAuthorizeNotification;
  */
 extern NSString* const SENAuthorizationServiceDidDeauthorizeNotification;
 
+/**
+ * Notification sent when a user is reauthorized
+ */
+extern NSString* const SENAuthorizationServiceDidReauthorizeNotification;
+
 @interface SENAuthorizationService : NSObject
 
 /**
@@ -22,6 +27,16 @@ extern NSString* const SENAuthorizationServiceDidDeauthorizeNotification;
  *  @param block    a block invoked after the authentication attempt is completed
  */
 + (void)authorizeWithUsername:(NSString*)username password:(NSString*)password callback:(void (^)(NSError* error))block;
+
+/**
+ * Reauthorizes the currently signed in user using the new password so that the
+ * authorization token reflects the change.  Future requests will use the updated
+ * token.
+ *
+ *  @param password the password for the given username
+ *  @param block    a block invoked after the authentication attempt is completed
+ */
++ (void)reauthorizeUserWithPassword:(NSString*)password callback:(void(^)(NSError* error))block;
 
 /**
  *  Load any cached credentials for use in API requests


### PR DESCRIPTION
**changes**
1. Created method to reauthorize the user with a new password.  This is needed so that the authorization notification is not sent, but instead the reauthorization method is called instead
2. updated account service so it doesn't have to refresh the account if email is not set since it's no longer needed.
