### PR TITLE
Turn off checking for surveys or notifications at launch

### DIFF
--- a/Pod/Classes/Analytics/SENAnalyticsMixpanel.m
+++ b/Pod/Classes/Analytics/SENAnalyticsMixpanel.m
@@ -18,8 +18,9 @@
              @"provider token is required");
 #endif
     
-    [Mixpanel sharedInstanceWithToken:dictionary[kSENAnalyticsProviderToken]];
-
+    Mixpanel* mixpanel = [Mixpanel sharedInstanceWithToken:dictionary[kSENAnalyticsProviderToken]];
+    mixpanel.checkForNotificationsOnActive = NO;
+    mixpanel.checkForSurveysOnActive = NO;
 }
 
 - (void)userWithId:(NSString *)userId didSignupWithProperties:(NSDictionary *)properties {


### PR DESCRIPTION
Prevent Mixpanel from reaching [here](https://github.com/mixpanel/mixpanel-iphone/blob/v2.4.2/Mixpanel/Mixpanel.m#L918) by turning off checks for notifications or surveys at app launch. Should fix crash in `-[Mixpanel checkForDecideResponseWithCompletion:]`
