### PR TITLE
add method to replace paired sense in device service

### DIFF
--- a/Pod/Classes/Service/SENServiceDevice.h
+++ b/Pod/Classes/Service/SENServiceDevice.h
@@ -33,7 +33,8 @@ typedef NS_ENUM(NSInteger, SENServiceDeviceError) {
     SENServiceDeviceErrorPillNotPaired = -5,
     SENServiceDeviceErrorUnpairPillFromSense = -6,
     SENServiceDeviceErrorUnlinkPillFromAccount = -7,
-    SENServiceDeviceErrorUnlinkSenseFromAccount = -8
+    SENServiceDeviceErrorUnlinkSenseFromAccount = -8,
+    SENServiceDeviceErrorSenseNotMatching = -9
 };
 
 typedef void(^SENServiceDeviceCompletionBlock)(NSError* error);
@@ -249,5 +250,17 @@ typedef void(^SENServiceDeviceCompletionBlock)(NSError* error);
  * @param completion: the block to invoke when done
  */
 - (void)setLEDState:(SENSenseLEDState)state completion:(SENServiceDeviceCompletionBlock)completion;
+
+/**
+ * Replace the current senseManager with the specified manager, if and only if
+ * the manager's sense matches what the account is linked to
+ *
+ * This is useful if caller is re-pairing Sense to an existing account
+ *
+ * @param senseManager: the manager initialized with Sense
+ * @param completion:   the block to invoke when an Error is encountered, or when it's done replacing
+ */
+- (void)replaceWithNewlyPairedSenseManager:(SENSenseManager*)senseManager
+                                completion:(void(^)(NSError* error))completion;
 
 @end

--- a/Pod/Classes/Service/SENServiceDevice.m
+++ b/Pod/Classes/Service/SENServiceDevice.m
@@ -398,6 +398,27 @@ NSString* const SENServiceDeviceErrorDomain = @"is.hello.service.device";
 
 #pragma mark - Pairing
 
+- (void)replaceWithNewlyPairedSenseManager:(SENSenseManager*)senseManager
+                                completion:(void(^)(NSError* error))completion {
+    if (senseManager == nil || [senseManager  sense] == nil) {
+        if (completion) completion ([self errorWithType:SENServiceDeviceErrorSenseUnavailable]);
+        return;
+    }
+    // first, load devices info since it likely would have changed
+    __weak typeof(self) weakSelf = self;
+    [self loadDeviceInfo:^(NSError *error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (error == nil) {
+            if ([[[strongSelf senseInfo] deviceId] isEqualToString:[[senseManager sense] deviceId]]) {
+                [strongSelf setSenseManager:senseManager];
+            } else {
+                error = [strongSelf errorWithType:SENServiceDeviceErrorSenseNotMatching];
+            }
+        }
+        completion (error);
+    }];
+}
+
 - (BOOL)pairedSenseAvailable {
     return [self senseManager] != nil;
 }


### PR DESCRIPTION
pretty straightforward, but enough code added to make me want a second pair of eyes.  a later PR will show how this is used, but basically when user re-pairs Sense, the experience without this is kind of bad and this helps by just reusing the sense manager that was just paired.
