### PR TITLE
Update reauthorization method signature to require username

### DIFF
--- a/Example/Tests/SENAuthorizationServiceSpec.m
+++ b/Example/Tests/SENAuthorizationServiceSpec.m
@@ -111,59 +111,6 @@ describe(@"SENAuthorizationService", ^{
             });
         });
     });
-
-    describe(@"+ emailAddressOfAuthorizedUser", ^{
-
-        NSString* emailAddress = @"someguy@example.com";
-
-        it(@"returns nil", ^{
-            [[[SENAuthorizationService emailAddressOfAuthorizedUser] should] beNil];
-        });
-
-        context(@"a user successfully authenticates", ^{
-
-            beforeEach(^{
-                stubRequest(@"POST", @"https://dev-api.hello.is/v1/oauth2/token");
-                [SENAuthorizationService stub:@selector(authorize:password:onCompletion:) withBlock:^id(NSArray *params) {
-                    void(^callback)(NSDictionary* response, NSError* error) = [params lastObject];
-                    if (callback) callback (nil, nil);
-                    return nil;
-                }];
-                [SENAuthorizationService authorizeWithUsername:emailAddress password:@"pass" callback:NULL];
-            });
-
-            it(@"returns the authenticating username", ^{
-                [[expectFutureValue([SENAuthorizationService emailAddressOfAuthorizedUser]) shouldSoon] equal:emailAddress];
-            });
-
-            context(@"a user signs out", ^{
-
-                beforeEach(^{
-                    [SENAuthorizationService deauthorize];
-                });
-
-                it(@"returns nil", ^{
-                    [[[SENAuthorizationService emailAddressOfAuthorizedUser] should] beNil];
-                });
-            });
-        });
-
-        context(@"a user fails to authenticate", ^{
-
-            beforeEach(^{
-                [SENAuthorizationService stub:@selector(authorize:password:onCompletion:) withBlock:^id(NSArray *params) {
-                    void(^callback)(NSDictionary* response, NSError* error) = [params lastObject];
-                    if (callback) callback (nil, [NSError errorWithDomain:@"auth.test" code:-1 userInfo:nil]);
-                    return nil;
-                }];
-                [SENAuthorizationService authorizeWithUsername:emailAddress password:@"pass" callback:NULL];
-            });
-
-            it(@"returns nil", ^{
-                [[[SENAuthorizationService emailAddressOfAuthorizedUser] should] beNil];
-            });
-        });
-    });
     
     describe(@"+ reauthorizeUserWithPassword:callback", ^{
         
@@ -178,20 +125,11 @@ describe(@"SENAuthorizationService", ^{
         it(@"should make a callback", ^{
             
             __block BOOL called = NO;
-            [SENAuthorizationService reauthorizeUserWithPassword:@"newpass" callback:^(NSError *error) {
+            [SENAuthorizationService reauthorizeUser:@"username" password:@"newpass" callback:^(NSError *error) {
                 called = YES;
             }];
             
-            [[expectFutureValue(@(called)) shouldSoon] equal:@(YES)];
-        });
-        
-        it(@"email of user should still be the same as initial authorization", ^{
-            
-            NSString* emailAddress = @"someguy@example.com";
-            [SENAuthorizationService authorizeWithUsername:emailAddress password:@"pass" callback:^(NSError *error) {
-                [SENAuthorizationService reauthorizeUserWithPassword:@"newpass" callback:nil];
-                [[expectFutureValue([SENAuthorizationService emailAddressOfAuthorizedUser]) shouldEventually] equal:emailAddress];
-            }];
+            [[@(called) should] equal:@(YES)];
         });
         
     });

--- a/Example/Tests/SENServiceAccountSpec.m
+++ b/Example/Tests/SENServiceAccountSpec.m
@@ -46,7 +46,7 @@ describe(@"SENServiceAccountSpec", ^{
         it(@"should return error if passwords are not provided", ^{
             
             __block NSError* invalidError = nil;
-            [[SENServiceAccount sharedService] changePassword:nil toNewPassword:@"test123" completion:^(NSError *error) {
+            [[SENServiceAccount sharedService] changePassword:nil toNewPassword:@"test123" forUsername:@"test" completion:^(NSError *error) {
                 invalidError = error;
             }];
             

--- a/Pod/Classes/API/SENAuthorizationService.h
+++ b/Pod/Classes/API/SENAuthorizationService.h
@@ -33,10 +33,11 @@ extern NSString* const SENAuthorizationServiceDidReauthorizeNotification;
  * authorization token reflects the change.  Future requests will use the updated
  * token.
  *
+ *  @param username the username of the entity to authorize
  *  @param password the password for the given username
  *  @param block    a block invoked after the authentication attempt is completed
  */
-+ (void)reauthorizeUserWithPassword:(NSString*)password callback:(void(^)(NSError* error))block;
++ (void)reauthorizeUser:(NSString*)username password:(NSString*)password callback:(void(^)(NSError* error))block;
 
 /**
  *  Load any cached credentials for use in API requests
@@ -70,11 +71,6 @@ extern NSString* const SENAuthorizationServiceDidReauthorizeNotification;
  *  @return YES if the request has an authorization header set
  */
 + (BOOL)isAuthorizedRequest:(NSURLRequest*)request;
-
-/**
- *  Authenticated email address or nil
- */
-+ (NSString*)emailAddressOfAuthorizedUser;
 
 /**
  * @return authenticated account id or nil

--- a/Pod/Classes/Service/SENServiceAccount.h
+++ b/Pod/Classes/Service/SENServiceAccount.h
@@ -43,10 +43,12 @@ typedef NS_ENUM(NSUInteger, SENServiceAccountError) {
  *
  * @param currentPassword: the current password used for the account
  * @param password:        the new password
+ * @param username:        the username of the account
  * @param completion:      optional block to invoke when all is done
  */
 - (void)changePassword:(NSString*)currentPassword
          toNewPassword:(NSString*)password
+           forUsername:(NSString*)username
             completion:(SENAccountResponseBlock)completion;
 
 /**

--- a/Pod/Classes/Service/SENServiceAccount.m
+++ b/Pod/Classes/Service/SENServiceAccount.m
@@ -178,6 +178,7 @@ static NSString* const SENServiceAccountErrorDomain = @"is.hello.service.account
 
 - (void)changePassword:(NSString*)currentPassword
          toNewPassword:(NSString*)password
+           forUsername:(NSString*)username
             completion:(SENAccountResponseBlock)completion {
     
     if ([currentPassword length] == 0 || [password length] == 0) {
@@ -195,8 +196,7 @@ static NSString* const SENServiceAccountErrorDomain = @"is.hello.service.account
                           return;
                       }
                       
-                      [SENAuthorizationService reauthorizeUserWithPassword:password
-                                                                  callback:completion];
+                      [SENAuthorizationService reauthorizeUser:username password:password callback:completion];
                       
                   }];
 }


### PR DESCRIPTION
**changes**
1. Require email/username for reauthorization.  This will help resolve bug https://trello.com/c/lmgmOrda/229-password-update-fails-if-you-update-your-email-first (requires suripu-ios update)
2. Remove the storage of the email address of the account in the keychain because this causes complexities in updating email address of the user since it doesn't have anything to do with authorization (not really at least).
