### PR TITLE
Delete sensors which aren’t refreshed

### DIFF
--- a/Pod/Classes/Model/SENSensor.m
+++ b/Pod/Classes/Model/SENSensor.m
@@ -86,6 +86,12 @@ static NSString* const SENSensorConditionWarningSymbol = @"WARNING";
             [[NSNotificationCenter defaultCenter] postNotificationName:SENSensorUpdateFailedNotification object:nil];
             return;
         }
+        NSArray* names = [data allKeys];
+        for (SENSensor* sensor in [self sensors]) {
+            if (![names containsObject:sensor.name]) {
+                [sensor delete];
+            }
+        }
         NSMutableArray* sensors = [[NSMutableArray alloc] initWithCapacity:[data count]];
         [data enumerateKeysAndObjectsUsingBlock:^(NSString* key, NSDictionary* obj, BOOL *stop) {
             NSMutableDictionary* values = [obj mutableCopy];
@@ -257,6 +263,11 @@ static NSString* const SENSensorConditionWarningSymbol = @"WARNING";
 {
     [SENKeyedArchiver setObject:self forKey:self.name inCollection:NSStringFromClass([SENSensor class])];
     [[NSNotificationCenter defaultCenter] postNotificationName:SENSensorUpdatedNotification object:self];
+}
+
+- (void)delete
+{
+    [SENKeyedArchiver removeAllObjectsForKey:self.name inCollection:NSStringFromClass([SENSensor class])];
 }
 
 #pragma mark formatting


### PR DESCRIPTION
Slight change which should improve the user experience.

Sensors which have no data to update are deleted, and the others are overwritten in place.
