### PR TITLE
add more descriptive ble error messages

### DIFF
--- a/Pod/Classes/Analytics/SENAnalytics.m
+++ b/Pod/Classes/Analytics/SENAnalytics.m
@@ -15,6 +15,7 @@ NSString* const kSENAnalyticsConfigAPIKey = @"kSENAnalyticsConfigAPIKey";
 NSString* const kSENAnalyticsPropConnection = @"connection";
 NSString* const kSENAnalyticsPropCode = @"code";
 NSString* const kSENAnalyticsPropMessage = @"message";
+NSString* const kSENAnalyticsPropDomain = @"domain";
 
 @implementation SENAnalytics
 
@@ -79,7 +80,8 @@ static NSMutableDictionary* providers;
     NSMutableDictionary* mutableProps = [NSMutableDictionary dictionaryWithCapacity:2];
     if ([error isKindOfClass:[NSError class]]) { // making sure error is an error.  sometimes it can be NSNull...
         [mutableProps setValue:@([error code]) forKey:kSENAnalyticsPropCode];
-        [mutableProps setValue:[error description] forKey:kSENAnalyticsPropMessage];
+        [mutableProps setValue:[error localizedDescription] forKey:kSENAnalyticsPropMessage];
+        [mutableProps setValue:[error domain] forKey:kSENAnalyticsPropDomain];
     }
     [providers enumerateKeysAndObjectsUsingBlock:^(NSNumber* key, id<SENAnalyticsProvider> provider, BOOL *stop) {
         [provider track:eventName withProperties:mutableProps];

--- a/Pod/Classes/BLE/SENSenseManager.h
+++ b/Pod/Classes/BLE/SENSenseManager.h
@@ -42,7 +42,7 @@ typedef NS_ENUM (NSInteger, SENSenseManagerErrorCode) {
     SENSenseManagerErrorCodeTimeout = -4,
     /** If Sense believes the mobile device has already been paired **/
     SENSenseManagerErrorCodeSenseAlreadyPaired = -5,
-    /** If some how the manager created a Sense messasge **/
+    /** If some how the manager created an invalid protobuf message**/
     SENSenseManagerErrorCodeInvalidCommand = -6,
     /** If some how, while sending a message, the connection fails **/
     SENSenseManagerErrorCodeConnectionFailed = -7,
@@ -62,8 +62,8 @@ typedef NS_ENUM (NSInteger, SENSenseManagerErrorCode) {
      */
     SENSenseManagerErrorCodeWifiNotInRange = -13,
     /**
-     * If trying to set WiFi credentials and Sense reports back that the endpoint
-     * is not in range for Sense to connect to.
+     * If trying to set WiFi credentials and Sense reports back that it cannot
+     * connect to the network
      */
     SENSenseManagerErrorCodeWLANConnection = -14,
     /**
@@ -76,8 +76,7 @@ typedef NS_ENUM (NSInteger, SENSenseManagerErrorCode) {
      */
     SENSenseManagerErrorCodeUnexpectedDisconnect = -16,
     /**
-     * Error code returned from an instance of SENSenseManager if an unexpected
-     * disconnect occurred while connected to Sense.
+     * If Sense returned that it encountered an internal data error
      */
     SENSenseManagerErrorCodeCorruptTransmission = -17
 };

--- a/Pod/Classes/Model/SENSense.m
+++ b/Pod/Classes/Model/SENSense.m
@@ -68,7 +68,7 @@
 }
 
 - (NSString*)description {
-    return [NSString stringWithFormat:@"Sense: %@, in mode: %ld", [self name], (long)[self mode]];
+    return [NSString stringWithFormat:@"Sense: %@, in mode: %ld, id: %@", [self name], (long)[self mode], [self deviceId]];
 }
 
 - (BOOL)isEqual:(id)object {


### PR DESCRIPTION
**CHANGES**
1. adding description to errors that are outputted from SENSenseManager to indicate area of failure
2. when tracking errors in analytics, log the localized description and domain separately
