### PR TITLE
supporting 2 version of firmware that addresses WEP issues

### DIFF
--- a/Pod/Classes/BLE/SENSenseManager.m
+++ b/Pod/Classes/BLE/SENSenseManager.m
@@ -1094,15 +1094,13 @@ typedef BOOL(^SENSenseUpdateBlock)(id response);
                    withSecurityType:(SENWifiEndpointSecurityType)type
                     formattingError:(NSError**)error {
     switch (type) {
+        case SENWifiEndpointSecurityTypeOpen:
+            return nil;
         case SENWifiEndpointSecurityTypeWep: {
             if ([self messageVersion] == kSENSensePVTMessageVersion) {
                 return [self dataValueForWepNetworkKey:password error:error];
-            } else {
-                return [password dataUsingEncoding:NSUTF8StringEncoding];
-            }
+            } // else, let it go through to default like all other types
         }
-        case SENWifiEndpointSecurityTypeOpen:
-            return nil;
         case SENWifiEndpointSecurityTypeWpa:
         case SENWifiEndpointSecurityTypeWpa2:
         default:


### PR DESCRIPTION
the latest firmware branch, which has not been released, will pivot on the message version.  If it's 0, it will accept the wep password as a byte array.  If it's 1, it will do it's own encoding which will fix another issue where a passcode with 00 will fail b/c of the use of strlen in the firmware.
