### PR TITLE
Fix a couple of device settings bugs

### DIFF
--- a/Pod/Classes/Service/SENServiceDevice.h
+++ b/Pod/Classes/Service/SENServiceDevice.h
@@ -92,13 +92,14 @@ typedef void(^SENServiceDeviceCompletionBlock)(NSError* error);
 + (instancetype)sharedService;
 
 /**
- * @method clearCache:
+ * @method reset:
  *
  * @discussion
- * Clear the cache of device information and state of the center.  You should
- * only do this if switching users or resetting back to factory.
+ * Clear the cache of device information and reset service as if it was just
+ * initialized.  You should only do this if switching users or resetting back 
+ * to factory.
  */
-- (void)clearCache;
+- (void)reset;
 
 /**
  * Clears the cache and resets any device states that was cached from previous


### PR DESCRIPTION
https://trello.com/c/2GhM7zd5/30-replace-sense-device-settings-does-not-disconnect-from-sense-if-connected

https://trello.com/c/05VSP6nW/31-is-hello-ble-wifi-1-bug

**changes**
1. make it clear what happens when clearing device states, which is to really just reset device checks and nothing else such as clearing the sense manager causing 1 of the bugs
2. change `clearCache` to `reset` device service to initial state, called on factory reset and signing out.  This should make it clearer what it does
3. upon unlinking sense from account, make sure to disconnect from Sense
4. tests for the changes

**NOTE**

there will be a companion suripu-ios PR for this
